### PR TITLE
fix(olx): preserve flashcards import/export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 1.0.2rc3 — 2026-06-02
+
+- Preserve flashcards content, display name, and styling during OLX import/export.
+- Fix Studio clipboard copy/paste by restoring proper OLX serialization and deserialization for flashcards.

--- a/flashcards/flashcards.py
+++ b/flashcards/flashcards.py
@@ -74,7 +74,7 @@ class FlashcardsXBlock(XBlock):
         ]
         block.content = flashcards
 
-        block.display_name = node.attrib.get("title", "Flashcards")
+        block.display_name = node.attrib.get("display_name") or node.attrib.get("title", "Flashcards")
 
         styling_attr = node.attrib.get("styling")
         if styling_attr:
@@ -92,12 +92,9 @@ class FlashcardsXBlock(XBlock):
         node.tag = self.xml_element_name()
         node.set("xblock-family", self.entry_point)
 
-        # Export display_name as the ``title`` attribute for OLX compatibility.
-        node.set("title", self.display_name)
-
         # Export remaining fields (skip content — handled as children below).
         for field_name, field in self.fields.items():
-            if field_name in ("children", "parent", "content", "display_name"):
+            if field_name in ("children", "parent", "content"):
                 continue
             if field.is_set_on(self) or field.force_export:
                 self._add_field(node, field_name, field)
@@ -115,7 +112,7 @@ class FlashcardsXBlock(XBlock):
             (
                 "FlashcardsXBlock",
                 """<vertical_demo>
-                <flashcards title="Capital cities">
+                <flashcards display_name="Capital cities">
 <flashcard front="Croatia" back="Zagreb" />
 <flashcard front="France" back="Paris" />
                 </flashcards>

--- a/flashcards/flashcards.py
+++ b/flashcards/flashcards.py
@@ -5,6 +5,9 @@ Flashcards XBlock allows the editor to add a list of questions and
 answers (separated by a semicolon) which are then displayed as flashcards.
 """
 
+import json
+
+from lxml import etree
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.fields import Dict, List, Scope, String
@@ -56,27 +59,57 @@ class FlashcardsXBlock(XBlock):
         return frag
 
     @classmethod
-    def parse_xml(cls, node, runtime, keys, id_generator) -> XBlock:  # noqa: ANN001, ARG003
+    def parse_xml(cls, node, runtime, keys) -> XBlock:  # noqa: ANN001
         """
-        Parse the XML for an HTML block.
+        Parse the XML for a Flashcards block during OLX import.
 
-        The entire subtree under `node` is re-serialized, and set as the
-        content of the XBlock.
+        The content between the <flashcards> blocks is transformed
+        into a list of flashcard dicts and stored as ``content``.
 
-        The content between the <flashcards> blocks is being transformed
-        into a list of flashcard objects, and as such saved into the content class variable
-        (which is accessible with self.content)
+        ``styling`` and ``display_name`` are recovered from XML
+        attributes when present.
         """
         block = runtime.construct_xblock_from_class(cls, keys)
-        flashcards = []
 
         flashcards = [
-            {"front": element.attrib["front"], "back": element.attrib["back"]} for element in node.iter("flashcard")
+            {"front": element.attrib["front"], "back": element.attrib["back"]}
+            for element in node.iter("flashcard")
         ]
-
         block.content = flashcards
-        block.title = node.attrib["title"]
+
+        block.display_name = node.attrib.get("title", "Flashcards")
+
+        styling_attr = node.attrib.get("styling")
+        if styling_attr:
+            block.styling = block.fields["styling"].from_string(styling_attr)
+
         return block
+
+    def add_xml_to_node(self, node):  # noqa: ANN001
+        """
+        Serialize this XBlock to XML for OLX export.
+
+        The ``content`` list is exported as ``<flashcard>`` child elements,
+        matching the format that ``parse_xml`` expects.
+        """
+        node.tag = self.xml_element_name()
+        node.set("xblock-family", self.entry_point)
+
+        # Export display_name as the ``title`` attribute for OLX compatibility.
+        node.set("title", self.display_name)
+
+        # Export remaining fields (skip content — handled as children below).
+        for field_name, field in self.fields.items():
+            if field_name in ("children", "parent", "content", "display_name"):
+                continue
+            if field.is_set_on(self) or field.force_export:
+                self._add_field(node, field_name, field)
+
+        # Export content list as <flashcard> child elements.
+        for card in self.content:
+            child = etree.SubElement(node, "flashcard")
+            child.set("front", card.get("front", ""))
+            child.set("back", card.get("back", ""))
 
     @staticmethod
     def workbench_scenarios() -> list[tuple[str, str]]:

--- a/flashcards/flashcards.py
+++ b/flashcards/flashcards.py
@@ -5,8 +5,6 @@ Flashcards XBlock allows the editor to add a list of questions and
 answers (separated by a semicolon) which are then displayed as flashcards.
 """
 
-import json
-
 from lxml import etree
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock
@@ -72,8 +70,7 @@ class FlashcardsXBlock(XBlock):
         block = runtime.construct_xblock_from_class(cls, keys)
 
         flashcards = [
-            {"front": element.attrib["front"], "back": element.attrib["back"]}
-            for element in node.iter("flashcard")
+            {"front": element.attrib["front"], "back": element.attrib["back"]} for element in node.iter("flashcard")
         ]
         block.content = flashcards
 

--- a/mise.toml
+++ b/mise.toml
@@ -27,21 +27,21 @@ run = "uv sync"
 
 [tasks.quality]
 description = "Check coding style with ruff"
-run = "tox -e quality"
+run = "uv run tox -e quality"
 
 [tasks.test]
 description = "Run tests in the current virtualenv"
 depends = ["clean"]
-run = "pytest"
+run = "uv run pytest"
 
 [tasks.test-all]
 description = "Run all tests using tox"
-run = "tox --parallel"
+run = "uv run tox --parallel"
 
 [tasks.diff-cover]
 description = "Find diff lines that need test coverage"
 depends = ["test"]
-run = "diff-cover coverage.xml"
+run = "uv run diff-cover coverage.xml"
 
 [tasks.validate]
 description = "Run tests and quality checks"
@@ -57,7 +57,7 @@ uv lock --upgrade
 
 [tasks.lint]
 description = "Format and lint all files with ruff"
-run = "ruff format && ruff check --fix"
+run = "uv run ruff format && ruff check --fix"
 
 [tasks.common-constraints]
 description = "Download and process common constraints from edx-lint"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "FlashcardsXBlock"
-version = "1.0.2rc2"
+version = "1.0.2rc3"
 description = "A Flashcards XBlock for Open edX."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.11"

--- a/tests/test_flashcards.py
+++ b/tests/test_flashcards.py
@@ -82,10 +82,7 @@ def test_export_xml_with_empty_content():
 
 
 def test_export_parse_round_trip_with_styling():
-    """
-    Export then re-parse via 3-arg calling convention recovers
-    display_name, content, and custom styling.
-    """
+    """Export then re-parse via 3-arg calling convention recovers display_name, content, and custom styling."""
     scope_ids = ScopeIds("1", "flashcards", "3", "4")
     block = FlashcardsXBlock(ToyRuntime(), scope_ids=scope_ids)
     block.display_name = "Styled"

--- a/tests/test_flashcards.py
+++ b/tests/test_flashcards.py
@@ -50,11 +50,11 @@ def test_export_xml_with_list_content_succeeds():
     block.add_xml_to_node(node)  # must not raise
 
     assert node.tag == "flashcards"
-    assert node.get("title") == "Capitals"
+    assert node.get("display_name") == "Capitals"
     assert node.get("xblock-family") == "xblock.v1"
 
-    # display_name must not appear as a separate attr; title already carries it
-    assert node.get("display_name") is None
+    # title must not appear; display_name is the standard OLX attr
+    assert node.get("title") is None
 
     children = list(node)
     assert len(children) == 2
@@ -111,3 +111,45 @@ def test_export_parse_round_trip_with_styling():
         "textColor": "#000000",
         "borderColor": "#cccccc",
     }
+
+
+def test_import_legacy_title_attribute():
+    """
+    parse_xml should still handle legacy ``title`` attribute for backward compatibility.
+
+    Old OLX files written with ``title="..."`` must import correctly by mapping
+    the legacy attr to ``display_name``.
+    """
+    xml = '<flashcards title="Legacy Cards"><flashcard front="Q1" back="A1"/></flashcards>'
+    node = etree.fromstring(xml)
+    parsed = FlashcardsXBlock.parse_xml(
+        node,
+        ToyRuntime(),
+        ScopeIds("1", "flashcards", "3", "4"),
+    )
+    assert parsed.display_name == "Legacy Cards"
+    assert parsed.content == [{"front": "Q1", "back": "A1"}]
+
+
+def test_import_display_name_trumps_legacy_title():
+    """When both ``display_name`` and legacy ``title`` are present, ``display_name`` wins."""
+    xml = '<flashcards display_name="New Name" title="Old Name"><flashcard front="Q" back="A"/></flashcards>'
+    node = etree.fromstring(xml)
+    parsed = FlashcardsXBlock.parse_xml(
+        node,
+        ToyRuntime(),
+        ScopeIds("1", "flashcards", "3", "4"),
+    )
+    assert parsed.display_name == "New Name"
+
+
+def test_import_no_title_fallback_default():
+    """When neither display_name nor title is present, parse_xml defaults to "Flashcards"."""
+    xml = '<flashcards><flashcard front="Q" back="A"/></flashcards>'
+    node = etree.fromstring(xml)
+    parsed = FlashcardsXBlock.parse_xml(
+        node,
+        ToyRuntime(),
+        ScopeIds("1", "flashcards", "3", "4"),
+    )
+    assert parsed.display_name == "Flashcards"

--- a/tests/test_flashcards.py
+++ b/tests/test_flashcards.py
@@ -1,5 +1,6 @@
 """Tests for the FlashcardsXBlock."""
 
+from lxml import etree
 from xblock.fields import ScopeIds
 from xblock.test.toy_runtime import ToyRuntime
 
@@ -28,3 +29,88 @@ def test_studio_view_json_data():
     assert "flashcards" in as_dict["json_init_args"]
     assert "styling" in as_dict["json_init_args"]
     assert "url" in as_dict["json_init_args"]
+
+
+def test_export_xml_with_list_content_succeeds():
+    """
+    Verify that exporting produces valid OLX for list content.
+
+    The export should produce ``<flashcard>`` child elements rather than
+    trying to assign the raw Python list to the XML node text.
+    """
+    scope_ids = ScopeIds("1", "flashcards", "3", "4")
+    block = FlashcardsXBlock(ToyRuntime(), scope_ids=scope_ids)
+    block.display_name = "Capitals"
+    block.content = [
+        {"front": "Croatia", "back": "Zagreb"},
+        {"front": "France", "back": "Paris"},
+    ]
+
+    node = etree.Element("root")
+    block.add_xml_to_node(node)  # must not raise
+
+    assert node.tag == "flashcards"
+    assert node.get("title") == "Capitals"
+    assert node.get("xblock-family") == "xblock.v1"
+
+    # display_name must not appear as a separate attr; title already carries it
+    assert node.get("display_name") is None
+
+    children = list(node)
+    assert len(children) == 2
+
+    assert children[0].tag == "flashcard"
+    assert children[0].get("front") == "Croatia"
+    assert children[0].get("back") == "Zagreb"
+
+    assert children[1].tag == "flashcard"
+    assert children[1].get("front") == "France"
+    assert children[1].get("back") == "Paris"
+
+
+def test_export_xml_with_empty_content():
+    """Export should also succeed when content is empty."""
+    scope_ids = ScopeIds("1", "flashcards", "3", "4")
+    block = FlashcardsXBlock(ToyRuntime(), scope_ids=scope_ids)
+    block.content = []
+
+    node = etree.Element("root")
+    block.add_xml_to_node(node)
+
+    assert node.tag == "flashcards"
+    assert list(node) == []  # no child elements
+
+
+def test_export_parse_round_trip_with_styling():
+    """
+    Export then re-parse via 3-arg calling convention recovers
+    display_name, content, and custom styling.
+    """
+    scope_ids = ScopeIds("1", "flashcards", "3", "4")
+    block = FlashcardsXBlock(ToyRuntime(), scope_ids=scope_ids)
+    block.display_name = "Styled"
+    block.content = [{"front": "Q", "back": "A"}]
+    block.styling = {
+        "fontSize": "24px",
+        "backgroundColor": "#ffffff",
+        "textColor": "#000000",
+        "borderColor": "#cccccc",
+    }
+
+    node = etree.Element("root")
+    block.add_xml_to_node(node)
+
+    # parse_xml(node, runtime, keys) — the canonical 3-arg OLX import call
+    parsed = FlashcardsXBlock.parse_xml(
+        node,
+        ToyRuntime(),
+        ScopeIds("1", "flashcards", "3", "4"),
+    )
+    assert parsed.display_name == "Styled"
+    assert parsed.content == [{"front": "Q", "back": "A"}]
+    assert parsed.styling == {
+        "fontSize": "24px",
+        "backgroundColor": "#ffffff",
+        "textColor": "#000000",
+        "borderColor": "#cccccc",
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -340,7 +340,7 @@ wheels = [
 
 [[package]]
 name = "flashcardsxblock"
-version = "1.0.0rc2"
+version = "1.0.2rc3"
 source = { virtual = "." }
 dependencies = [
     { name = "xblock" },


### PR DESCRIPTION
## Description

Fixes export-import and copy-paste. Previously raised below error when trying to export the block.

```log
[2026-05-15 22:15:19,646: ERROR/ForkPoolWorker-17] cms.djangoapps.contentstore.tasks.export_olx[122903c1-9bad-4bd6-a032-9ff16f8a7d76]: Error exporting course course-v   │
│ Traceback (most recent call last):                                                                                                                                     │
│   File "/openedx/edx-platform/cms/djangoapps/contentstore/tasks.py", line 339, in export_olx                                                                           │
│     tarball = create_export_tarball(courselike_block, courselike_key, {}, self.status)                                                                                 │
│               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                 │
│   File "/openedx/edx-platform/cms/djangoapps/contentstore/tasks.py", line 366, in create_export_tarball                                                                │
│     export_course_to_xml(modulestore(), contentstore(), course_block.id, root_dir, name)                                                                               │
│   File "/openedx/edx-platform/xmodule/modulestore/xml_exporter.py", line 356, in export_course_to_xml                                                                  │
│     CourseExportManager(modulestore, contentstore, course_key, root_dir, course_dir).export()                                                                          │
│   File "/openedx/edx-platform/xmodule/modulestore/xml_exporter.py", line 174, in export                                                                                │
│     courselike.add_xml_to_node(root)                                                                                                                                   │
│   File "/openedx/edx-platform/xmodule/xml_block.py", line 427, in add_xml_to_node                                                                                      │
│     xml_object = self.definition_to_xml(self.runtime.export_fs)                                                                                                        │
│                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                        │
│   File "/openedx/edx-platform/xmodule/course_block.py", line 1217, in definition_to_xml                                                                                │
│     xml_object = super().definition_to_xml(resource_fs)                                                                                                                │
│                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                │
│   File "/openedx/edx-platform/xmodule/seq_block.py", line 978, in definition_to_xml                                                                                    │
│     self.runtime.add_block_as_child_node(child, xml_object)                                                                                                            │
│   File "/openedx/edx-platform/xmodule/x_module.py", line 1477, in add_block_as_child_node                                                                              │
│     block.add_xml_to_node(child)                                                                                                                                       │
│   File "/openedx/edx-platform/xmodule/xml_block.py", line 427, in add_xml_to_node                                                                                      │
│     xml_object = self.definition_to_xml(self.runtime.export_fs)                                                                                                        │
│                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                        │
│   File "/openedx/edx-platform/xmodule/seq_block.py", line 978, in definition_to_xml                                                                                    │
│     self.runtime.add_block_as_child_node(child, xml_object)                                                                                                            │
│   File "/openedx/edx-platform/xmodule/x_module.py", line 1477, in add_block_as_child_node                                                                              │
│     block.add_xml_to_node(child)                                                                                                                                       │
│   File "/openedx/edx-platform/xmodule/xml_block.py", line 427, in add_xml_to_node                                                                                      │
│     xml_object = self.definition_to_xml(self.runtime.export_fs)                                                                                                        │
│                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                        │
│   File "/openedx/edx-platform/xmodule/seq_block.py", line 978, in definition_to_xml                                                                                    │
│     self.runtime.add_block_as_child_node(child, xml_object)                                                                                                            │
│   File "/openedx/edx-platform/xmodule/x_module.py", line 1477, in add_block_as_child_node                                                                              │
│     block.add_xml_to_node(child)                                                                                                                                       │
│   File "/openedx/edx-platform/xmodule/xml_block.py", line 427, in add_xml_to_node                                                                                      │
│     xml_object = self.definition_to_xml(self.runtime.export_fs)                                                                                                        │
│                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                        │
│   File "/openedx/edx-platform/xmodule/vertical_block.py", line 264, in definition_to_xml                                                                               │
│     self.runtime.add_block_as_child_node(child, xml_object)                                                                                                            │
│   File "/openedx/edx-platform/xmodule/x_module.py", line 1477, in add_block_as_child_node                                                                              │
│     block.add_xml_to_node(child)                                                                                                                                       │
│   File "/openedx/venv/lib/python3.11/site-packages/xblock/core.py", line 833, in add_xml_to_node                                                                       │
│     super().add_xml_to_node(node)                                                                                                                                      │
│   File "/openedx/venv/lib/python3.11/site-packages/xblock/core.py", line 581, in add_xml_to_node                                                                       │
│     node.text = text                                                                                                                                                   │
│     ^^^^^^^^^                                                                                                                                                          │
│   File "src/lxml/etree.pyx", line 1049, in lxml.etree._Element.text.__set__                                                                                            │
│   File "src/lxml/apihelpers.pxi", line 748, in lxml.etree._setNodeText                                                                                                 │
│   File "src/lxml/apihelpers.pxi", line 736, in lxml.etree._createTextNode                                                                                              │
│   File "src/lxml/apihelpers.pxi", line 1539, in lxml.etree._utf8                                                                                                       │
│ TypeError: Argument must be bytes or unicode, got 'list'
```

## Supported info

* `Private-ref`: https://tasks.opencraft.com/browse/FAL-4355

## Test instructions

* Install flashcards xblock
* Add "flashcards" to advanced module list in advanced settings page.
* Add some flashcards blocks in the outline
* Export and import the course.

**Merge checklist:**

Check off if complete *or* not applicable:

* [x] Version bumped
* [x] Changelog record added
* [x] Documentation updated (not only docstrings)
* [x] Fixup commits are squashed away
* [x] Unit tests added/updated
* [x] Manual testing instructions provided
* [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets


**Co-authored by:** GPT 5.4